### PR TITLE
Reducing CPU util and removing build error caused by catkin_simple

### DIFF
--- a/nodes/deeplab_ros_node.py
+++ b/nodes/deeplab_ros_node.py
@@ -95,7 +95,7 @@ class DeepLabNode(object):
         rgb_image = PIL.Image.fromarray(rgb_image)
 
         resized_im, seg_map = self._model.run(rgb_image)
-        seg_map = cv2.resize(seg_map.astype(np.float32), rgb_image.size).astype(np.uint16)
+        seg_map = cv2.resize(seg_map.astype(np.float32), rgb_image.size, interpolation = cv2.INTER_NEAREST).astype(np.uint16)
 
         return seg_map
 

--- a/nodes/deeplab_ros_node.py
+++ b/nodes/deeplab_ros_node.py
@@ -6,7 +6,6 @@ from six.moves import urllib
 
 import PIL
 import numpy as np
-from skimage import transform
 import cv2
 
 import tensorflow as tf
@@ -96,10 +95,7 @@ class DeepLabNode(object):
         rgb_image = PIL.Image.fromarray(rgb_image)
 
         resized_im, seg_map = self._model.run(rgb_image)
-        target_size = rgb_image.size[::-1]
-        seg_map = transform.resize(
-            seg_map, target_size, order=0, preserve_range=True).astype(
-                np.uint16)
+        seg_map = cv2.resize(seg_map.astype(np.float32), rgb_image.size).astype(np.uint16)
 
         return seg_map
 

--- a/package.xml
+++ b/package.xml
@@ -12,4 +12,5 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>rospy</depend>
+  <depend>catkin_simple</depend>
 </package>


### PR DESCRIPTION
*   Switching to cv2 for image resize to reduce cpu util
*   Add catkin_simple dependency in package.xml to get rid of build error